### PR TITLE
Add esbuild build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "esbuild js/main.js --bundle --minify --outfile=js/bundle.js"
+  },
+  "devDependencies": {
+    "esbuild": "^0.19.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add npm `build` script using esbuild
- note: esbuild dev dependency added manually; installation failed in environment

## Testing
- `npm run build` *(fails: esbuild: not found)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a7669b5464832b80abf5cab10a6508