### PR TITLE
Allow gallery display alongside timeline content

### DIFF
--- a/js/utils/is.js
+++ b/js/utils/is.js
@@ -39,7 +39,10 @@ function isChecker(instance = null) {
     },
     hasGallery() {
       const data = instance.currentYearTimelineData;
-      return !!data?.galleryId && (!data.spots || data.spots.length === 0);
+      return (
+        !!data?.galleryId ||
+        isChecker.hasContent(instance.currentYearGalleryImages)
+      );
     },
     hasGalleryImages() {
       return isChecker.hasContent(instance.currentYearGalleryImages);


### PR DESCRIPTION
## Summary
- check `hasGallery` using gallery ID or populated images instead of requiring empty timeline spots

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: esbuild not found)
- `npm install` (fails: 403 Forbidden)
- `node --input-type=module -e 'import isChecker from "./js/utils/is.js"; const instance={currentYearTimelineData:{galleryId:"gal", spots:["spot"]}, currentYearGalleryImages:["img"], timeline:["spot"], showModal:false, $data:{}}; const ctx=isChecker(instance); instance.hasGallery=ctx.hasGallery(); console.log("hasGallery", instance.hasGallery); console.log("hasTimelineContent", isChecker.hasContent(instance.timeline)); console.log("showingMainGallery", ctx.showingMainGallery());'`


------
https://chatgpt.com/codex/tasks/task_e_68a770e03b00832b9cbcc87d5e69aa90